### PR TITLE
[BUGFIX] could not handle large files (> 4GB) in 32bits environments

### DIFF
--- a/ext/rfuse/filler.c
+++ b/ext/rfuse/filler.c
@@ -34,12 +34,12 @@ VALUE rfiller_push(VALUE self, VALUE name, VALUE stat, VALUE offset) {
 
   //Allow nil return instead of a stat
   if (NIL_P(stat)) {
-    result = f->filler(f->buffer,StringValueCStr(name),NULL,NUM2LONG(offset));
+    result = f->filler(f->buffer,StringValueCStr(name),NULL,NUM2OFFT(offset));
   } else {
     struct stat st;
     memset(&st, 0, sizeof(st));
     rstat2stat(stat,&st);
-    result = f->filler(f->buffer,StringValueCStr(name),&st,NUM2LONG(offset));
+    result = f->filler(f->buffer,StringValueCStr(name),&st,NUM2OFFT(offset));
   }
 
   return result ? Qnil : self;

--- a/ext/rfuse/helper.c
+++ b/ext/rfuse/helper.c
@@ -12,9 +12,9 @@ void rstat2stat(VALUE rstat, struct stat *statbuf)
   statbuf->st_uid     = FIX2UINT(rb_funcall(rstat,rb_intern("uid"),0));
   statbuf->st_gid     = FIX2UINT(rb_funcall(rstat,rb_intern("gid"),0));
   statbuf->st_rdev    = FIX2ULONG(rb_funcall(rstat,rb_intern("rdev"),0));
-  statbuf->st_size    = FIX2ULONG(rb_funcall(rstat,rb_intern("size"),0));
-  statbuf->st_blksize = NUM2ULONG(rb_funcall(rstat,rb_intern("blksize"),0));
-  statbuf->st_blocks  = NUM2ULONG(rb_funcall(rstat,rb_intern("blocks"),0));
+  statbuf->st_size    = NUM2OFFT(rb_funcall(rstat,rb_intern("size"),0));
+  statbuf->st_blksize = NUM2SIZET(rb_funcall(rstat,rb_intern("blksize"),0));
+  statbuf->st_blocks  = NUM2SIZET(rb_funcall(rstat,rb_intern("blocks"),0));
 
   r_atime = rb_funcall(rstat,rb_intern("atime"),0);
   r_mtime = rb_funcall(rstat,rb_intern("mtime"),0);

--- a/ext/rfuse/rfuse.c
+++ b/ext/rfuse/rfuse.c
@@ -144,7 +144,7 @@ static int rf_readdir(const char *path, void *buf,
   fillerc->filler=filler;
   fillerc->buffer=buf;
   args[3]=rfiller_instance;
-  args[4]=INT2NUM(offset);
+  args[4]=OFFT2NUM(offset);
   args[5]=get_file_info(ffi);
 
   rb_protect((VALUE (*)())unsafe_readdir,(VALUE)args,&error);
@@ -177,7 +177,7 @@ static int rf_readlink(const char *path, char *buf, size_t size)
   struct fuse_context *ctx=fuse_get_context();
   init_context_path_args(args,ctx,path);
   
-  args[3]=INT2NUM(size);
+  args[3]=SIZET2NUM(size);
   res=rb_protect((VALUE (*)())unsafe_readlink,(VALUE)args,&error);  
   if (error)
   {
@@ -844,8 +844,8 @@ static int rf_read(const char *path,char * buf, size_t size,off_t offset,struct 
   struct fuse_context *ctx=fuse_get_context();
   init_context_path_args(args,ctx,path);
   
-  args[3]=INT2NUM(size);
-  args[4]=INT2NUM(offset);
+  args[3]=SIZET2NUM(size);
+  args[4]=OFFT2NUM(offset);
   args[5]=get_file_info(ffi);
 
   res=rb_protect((VALUE (*)())unsafe_read,(VALUE) args,&error);
@@ -901,7 +901,7 @@ static int rf_write(const char *path,const char *buf,size_t size,
   init_context_path_args(args,ctx,path);
 
   args[3]=rb_str_new(buf, size);
-  args[4]=INT2NUM(offset);
+  args[4]=OFFT2NUM(offset);
   args[5]=get_file_info(ffi);
 
   res = rb_protect((VALUE (*)())unsafe_write,(VALUE) args, &error);
@@ -1387,7 +1387,7 @@ static int rf_ftruncate(const char *path, off_t size,
 
   struct fuse_context *ctx = fuse_get_context();
   init_context_path_args(args,ctx,path);
-  args[3] = INT2NUM(size);
+  args[3] = OFFT2NUM(size);
   args[4] = get_file_info(ffi);
 
   rb_protect((VALUE (*)())unsafe_ftruncate,(VALUE) args,&error);
@@ -1587,7 +1587,7 @@ static int rf_bmap(const char *path, size_t blocksize, uint64_t *idx)
 
   struct fuse_context *ctx = fuse_get_context();
   init_context_path_args(args,ctx,path);
-  args[3] = INT2NUM(blocksize);
+  args[3] = SIZET2NUM(blocksize);
   args[4] = LL2NUM(*idx);
 
   res = rb_protect((VALUE (*)())unsafe_bmap,(VALUE) args, &error);


### PR DESCRIPTION
Hi

Currently rfuse could not handle large files over 4GB in 32bits environment.
used NUM2OFFT, NUM2SIZET OFFT2NUM and SIZET2NUM instead of NUM2LONG and NUM2ULONG.
