### PR TITLE
Fix devices including '-'

### DIFF
--- a/lib/rfuse.rb
+++ b/lib/rfuse.rb
@@ -74,7 +74,7 @@ module RFuse
     def self.parse_options(argv,*local_opts)
         result = Hash.new(nil)
 
-        first_opt_index = (argv.find_index() { |opt| opt =~ /-.*/ } || argv.length )
+        first_opt_index = (argv.find_index() { |opt| opt =~ /^-.*/ } || argv.length )
 
         result[:device] = argv.shift if first_opt_index > 1
         result[:mountpoint] = argv[0] if argv.length > 0

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -131,5 +131,13 @@ describe RFuse do
             argv.should == [ "/mountpoint" , "-o", "rw,debug,default_permissions" ]
         end
 
+        context "with '-' in device" do
+            it "should parse the device correctly" do
+                argv = [ "a-device", "/mountpoint" , "-o", "rw,debug,default_permissions" ]
+                result = RFuse.parse_options(argv)
+
+                result[:device].should == "a-device"
+            end
+        end
     end
 end


### PR DESCRIPTION
This PR fixes passing devices containing '-', for example urls