### PR TITLE
[WIP] OSX Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 *.o
 *.so
 *.gem
+*.bundle
 doc
 .yardoc
+Gemfile.lock
+mkmf.log
+tmp/
+lib/rfuse/rfuse.bundle
+.RUBYARCHDIR*
+

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,10 @@ YARD::Rake::YardocTask.new
 
 Rake::ExtensionTask.new('rfuse') do |ext|
   ext.lib_dir = "lib/rfuse"
+
+  if RUBY_PLATFORM.include?('darwin')
+    ext.config_options << '--with-cflags="-D_FILE_OFFSET_BITS=64 -D_DARWIN_USE_64_BIT_INODE -I/usr/local/include/osxfuse"'
+  end
 end
 
 task :spec => :compile

--- a/ext/rfuse/extconf.rb
+++ b/ext/rfuse/extconf.rb
@@ -4,13 +4,14 @@ $CFLAGS << ' -Wall'
 #$CFLAGS << ' -Werror'
 $CFLAGS << ' -D_FILE_OFFSET_BITS=64'
 $CFLAGS << ' -DFUSE_USE_VERSION=26'
+$CFLAGS << ' -I/usr/local/include/osxfuse' if RUBY_PLATFORM =~ /darwin/
 
 
 have_func("rb_errinfo")
 
 have_func("rb_set_errinfo")
 
-if have_library('fuse')
+if have_library('fuse') || have_library('osxfuse')
   create_makefile('rfuse/rfuse')
 else
   puts "No FUSE install available"

--- a/ext/rfuse/file_info.c
+++ b/ext/rfuse/file_info.c
@@ -5,9 +5,9 @@
 VALUE wrap_file_info(struct fuse_context *ctx, struct fuse_file_info *ffi) {
   VALUE rRFuse;
   VALUE rFileInfo;
-  
+
   VALUE rffi;
- 
+
   VALUE open_files;
   VALUE key;
 
@@ -18,7 +18,7 @@ VALUE wrap_file_info(struct fuse_context *ctx, struct fuse_file_info *ffi) {
 
   //store the wrapped ffi back into the struct so we don't have to keep wrapping it
   ffi->fh = rffi;
- 
+
   //also store it in an open_files hash on the fuse_object
   //so it doesn't get GC'd
   open_files = rb_iv_get((VALUE) ctx->private_data,"@open_files");
@@ -30,15 +30,15 @@ VALUE wrap_file_info(struct fuse_context *ctx, struct fuse_file_info *ffi) {
 
 //returns a previously wrapped ffi
 VALUE get_file_info(struct fuse_file_info *ffi) {
-    
+
   if (TYPE(ffi->fh) == T_DATA )
       return (VALUE) ffi->fh;
   else
       return Qnil;
-  
+
 };
 
-//Allow the FileInfo object to be GC'd 
+//Allow the FileInfo object to be GC'd
 VALUE release_file_info(struct fuse_context *ctx, struct fuse_file_info *ffi)
 {
 
@@ -50,7 +50,7 @@ VALUE release_file_info(struct fuse_context *ctx, struct fuse_file_info *ffi)
       rb_hash_delete(open_files,key);
 
       return rffi;
-  } 
+  }
 
   return Qnil;
 
@@ -101,17 +101,23 @@ VALUE file_info_direct_assign(VALUE self,VALUE value) {
 VALUE file_info_nonseekable(VALUE self) {
    struct fuse_file_info *f;
    Data_Get_Struct(self,struct fuse_file_info,f);
-  if (TYPE(f->nonseekable) != T_NONE) {
-    return (VALUE) f->nonseekable;
-  } else {
-    return Qnil;
-  }
+#ifndef __APPLE__
+    if (TYPE(f->nonseekable) != T_NONE) {
+      return (VALUE) f->nonseekable;
+    } else {
+      return Qnil;
+    }
+#else
+   return Qnil;
+#endif
 }
 
 VALUE file_info_nonseekable_assign(VALUE self,VALUE value) {
    struct fuse_file_info *f;
    Data_Get_Struct(self,struct fuse_file_info,f);
-   f->nonseekable = value;
+#ifndef __APPLE__
+     f->nonseekable = value;
+#endif
    return value;
 }
 
@@ -136,7 +142,7 @@ void file_info_init(VALUE module) {
   rb_define_method(cFileInfo,"direct=",file_info_direct_assign,1);
   rb_define_method(cFileInfo,"nonseekable",file_info_nonseekable,0);
   rb_define_method(cFileInfo,"nonseekable=",file_info_nonseekable_assign,1);
-  
+
   /*
      @return [Object] user specified filehandle object. See {Fuse#open}
   */

--- a/ext/rfuse/helper.c
+++ b/ext/rfuse/helper.c
@@ -65,8 +65,10 @@ void rfuseconninfo2fuseconninfo(VALUE rfuseconninfo,struct fuse_conn_info *fusec
   fuseconninfo->async_read    = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("async_read"),0));
   fuseconninfo->max_write     = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("max_write"),0));
   fuseconninfo->max_readahead = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("max_readahead"),0));
-  fuseconninfo->capable       = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("capable"),0));
-  fuseconninfo->want          = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("want"),0));
+#ifndef __APPLE__
+    fuseconninfo->capable       = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("capable"),0));
+    fuseconninfo->want          = FIX2UINT(rb_funcall(rfuseconninfo,rb_intern("want"),0));
+#endif
 }
 
 struct fuse_args * rarray2fuseargs(VALUE rarray){
@@ -75,7 +77,7 @@ struct fuse_args * rarray2fuseargs(VALUE rarray){
   struct fuse_args *args;
   //TODO - we probably don't want to execute the rest if the type check fails
   Check_Type(rarray, T_ARRAY);
-  
+
   args = malloc(sizeof(struct fuse_args));
   args->argc      = RARRAY_LEN(rarray) + 1;
   args->argv      = malloc((args->argc + 1) * sizeof(char *));
@@ -88,10 +90,10 @@ struct fuse_args * rarray2fuseargs(VALUE rarray){
       VALUE v;
       v = RARRAY_PTR(rarray)[i];
       Check_Type(v, T_STRING);
-      args->argv[i+1] = strdup(rb_string_value_ptr(&v)); 
+      args->argv[i+1] = strdup(rb_string_value_ptr(&v));
   }
 
   args->argv[args->argc] = NULL;
-                        
+
   return args;
 }

--- a/ext/rfuse/pollhandle.c
+++ b/ext/rfuse/pollhandle.c
@@ -1,3 +1,4 @@
+#ifndef __APPLE__
 #include <ruby.h>
 #include <fuse.h>
 
@@ -52,3 +53,4 @@ VALUE pollhandle_init(VALUE module)
 
   return cPollHandle;
 }
+#endif


### PR DESCRIPTION
Hey @lwoggardner, I've been trying to cobble together the fixes from several open issues into one PR to support OSX. The problem I'm running into now is that `fusermount` isn't installed as part of the osxfuse project, but is [used in the spec helper](https://github.com/lwoggardner/rfuse/blob/master/spec/spec_helper.rb#L57). The equivalent seems to be `mount -t osxfuse -o nodev,nosuid,synchronous ruby@osxfuse0 ./path/to/mountpoint`, but all that does is spit out a usage message "This program is not meant to be called directly. The OSXFUSE library calls it." Any idea how I'm supposed to mount a fuse volume manually with the `mount` command? I tried following the comments above `self.parse_options`in fuse.rb, but I couldn't understand them. Thanks for your help!
